### PR TITLE
[T16] Fix rotary encoder

### DIFF
--- a/radio/src/targets/t16/keys_driver.cpp
+++ b/radio/src/targets/t16/keys_driver.cpp
@@ -20,57 +20,28 @@
 
 #include "opentx.h"
 
-/*
- * Rotary encoder handling based on state table:
- * Copyright (C) by Ben Buxton
- * 
- * This includes the state table definition bellow
- * as well as the implementation of checkRotaryEncoder().
- * 
- * The below state table has, for each state (row), the new state
- * to set based on the next encoder output. From left to right in,
- * the table, the encoder outputs are 00, 01, 10, 11, and the value
- * in that position is the new state to set.
- */
-
-#define R_START 0x0
-#define DIR_CW  0x10
-#define DIR_CCW 0x20
-
-// Use the half-step state table (emits a code at 00 and 11)
-#define R_CCW_BEGIN 0x1
-#define R_CW_BEGIN 0x2
-#define R_START_M 0x3
-#define R_CW_BEGIN_M 0x4
-#define R_CCW_BEGIN_M 0x5
-const unsigned char rotenc_table[6][4] = {
-  // R_START (00)
-  {R_START_M,            R_CW_BEGIN,     R_CCW_BEGIN,  R_START},
-  // R_CCW_BEGIN
-  {R_START_M | DIR_CCW, R_START,        R_CCW_BEGIN,  R_START},
-  // R_CW_BEGIN
-  {R_START_M | DIR_CW,  R_CW_BEGIN,     R_START,      R_START},
-  // R_START_M (11)
-  {R_START_M,            R_CCW_BEGIN_M,  R_CW_BEGIN_M, R_START},
-  // R_CW_BEGIN_M
-  {R_START_M,            R_START_M,      R_CW_BEGIN_M, R_START | DIR_CW},
-  // R_CCW_BEGIN_M
-  {R_START_M,            R_CCW_BEGIN_M,  R_START_M,    R_START | DIR_CCW},
-};
-
 void checkRotaryEncoder()
 {
   static uint8_t  state = 0;
   uint32_t pins = ROTARY_ENCODER_POSITION();
-  
-  state = rotenc_table[state & 0x0F][pins];
-  if ((state & 0x30) && !keyState(KEY_ENTER)) {
-    if ((state & 0x30) == DIR_CW) {
-      --rotencValue[0];
+
+  if (pins != (state & 0x03)) {
+    if ((pins & 0x01) ^ ((pins & 0x02) >> 1)) {
+      if ((state & 0x03) == 3)
+        ++rotencValue[0];
+      else
+        --rotencValue[0];
     }
-    else {
-      ++rotencValue[0];
+    else
+    {
+      if ((state & 0x03) == 3)
+         --rotencValue[0];
+      if ((state & 0x03) == 0)
+         ++rotencValue[0];
     }
+    state &= ~0x03 ;
+    state |= pins ;
+
 #if !defined(BOOT)
     if (g_eeGeneral.backlightMode & e_backlight_mode_keys)
       backlightOn();

--- a/radio/src/targets/t16/keys_driver.cpp
+++ b/radio/src/targets/t16/keys_driver.cpp
@@ -25,7 +25,7 @@ void checkRotaryEncoder()
   static uint8_t  state = 0;
   uint32_t pins = ROTARY_ENCODER_POSITION();
 
-  if (pins != (state & 0x03)) {
+  if (pins != (state & 0x03) && !keyState(KEY_ENTER)) {
     if ((pins & 0x01) ^ ((pins & 0x02) >> 1)) {
       if ((state & 0x03) == 3)
         ++rotencValue[0];
@@ -36,7 +36,7 @@ void checkRotaryEncoder()
     {
       if ((state & 0x03) == 3)
          --rotencValue[0];
-      if ((state & 0x03) == 0)
+      else if ((state & 0x03) == 0)
          ++rotencValue[0];
     }
     state &= ~0x03 ;

--- a/radio/src/targets/t16hd/keys_driver.cpp
+++ b/radio/src/targets/t16hd/keys_driver.cpp
@@ -20,57 +20,28 @@
 
 #include "opentx.h"
 
-/*
- * Rotary encoder handling based on state table:
- * Copyright (C) by Ben Buxton
- * 
- * This includes the state table definition bellow
- * as well as the implementation of checkRotaryEncoder().
- * 
- * The below state table has, for each state (row), the new state
- * to set based on the next encoder output. From left to right in,
- * the table, the encoder outputs are 00, 01, 10, 11, and the value
- * in that position is the new state to set.
- */
-
-#define R_START 0x0
-#define DIR_CW  0x10
-#define DIR_CCW 0x20
-
-// Use the half-step state table (emits a code at 00 and 11)
-#define R_CCW_BEGIN 0x1
-#define R_CW_BEGIN 0x2
-#define R_START_M 0x3
-#define R_CW_BEGIN_M 0x4
-#define R_CCW_BEGIN_M 0x5
-const unsigned char rotenc_table[6][4] = {
-  // R_START (00)
-  {R_START_M,            R_CW_BEGIN,     R_CCW_BEGIN,  R_START},
-  // R_CCW_BEGIN
-  {R_START_M | DIR_CCW, R_START,        R_CCW_BEGIN,  R_START},
-  // R_CW_BEGIN
-  {R_START_M | DIR_CW,  R_CW_BEGIN,     R_START,      R_START},
-  // R_START_M (11)
-  {R_START_M,            R_CCW_BEGIN_M,  R_CW_BEGIN_M, R_START},
-  // R_CW_BEGIN_M
-  {R_START_M,            R_START_M,      R_CW_BEGIN_M, R_START | DIR_CW},
-  // R_CCW_BEGIN_M
-  {R_START_M,            R_CCW_BEGIN_M,  R_START_M,    R_START | DIR_CCW},
-};
-
 void checkRotaryEncoder()
 {
   static uint8_t  state = 0;
   uint32_t pins = ROTARY_ENCODER_POSITION();
-  
-  state = rotenc_table[state & 0x0F][pins];
-  if ((state & 0x30) && !keyState(KEY_ENTER)) {
-    if ((state & 0x30) == DIR_CW) {
-      --rotencValue[0];
+
+  if (pins != (state & 0x03)) {
+    if ((pins & 0x01) ^ ((pins & 0x02) >> 1)) {
+      if ((state & 0x03) == 3)
+        ++rotencValue[0];
+      else
+        --rotencValue[0];
     }
-    else {
-      ++rotencValue[0];
+    else
+    {
+      if ((state & 0x03) == 3)
+         --rotencValue[0];
+      if ((state & 0x03) == 0)
+         ++rotencValue[0];
     }
+    state &= ~0x03 ;
+    state |= pins ;
+
 #if !defined(BOOT)
     if (g_eeGeneral.backlightMode & e_backlight_mode_keys)
       backlightOn();

--- a/radio/src/targets/t16hd/keys_driver.cpp
+++ b/radio/src/targets/t16hd/keys_driver.cpp
@@ -25,7 +25,7 @@ void checkRotaryEncoder()
   static uint8_t  state = 0;
   uint32_t pins = ROTARY_ENCODER_POSITION();
 
-  if (pins != (state & 0x03)) {
+  if (pins != (state & 0x03) && !keyState(KEY_ENTER)) {
     if ((pins & 0x01) ^ ((pins & 0x02) >> 1)) {
       if ((state & 0x03) == 3)
         ++rotencValue[0];
@@ -36,7 +36,7 @@ void checkRotaryEncoder()
     {
       if ((state & 0x03) == 3)
          --rotencValue[0];
-      if ((state & 0x03) == 0)
+      else if ((state & 0x03) == 0)
          ++rotencValue[0];
     }
     state &= ~0x03 ;


### PR DESCRIPTION
Rotary encoder wheel required 2 "clicks" to register one event.
Fix for T16 & T16HD