### PR TITLE
fixes issue 11: build for T12 after PR 9

### DIFF
--- a/radio/src/pulses/multi_arm.cpp
+++ b/radio/src/pulses/multi_arm.cpp
@@ -37,7 +37,9 @@ void sendChannels(uint8_t port);
 
 void sendMulti(uint8_t port, uint8_t b) {
   if(port == INTERNAL_MODULE){
-    *modulePulsesData[port].pxx_uart.ptr++ = b;
+    #if defined(INTMODULE_USART) || defined(EXTMODULE_USART)
+      *modulePulsesData[port].pxx_uart.ptr++ = b;
+    #endif
   }
   else sendByteSbus(port, b);
 }
@@ -98,7 +100,9 @@ void setupPulsesMultimodule(uint8_t port)
   static int counter = 0;
   if(port == INTERNAL_MODULE)
   {
-    modulePulsesData[port].pxx_uart.ptr = modulePulsesData[port].pxx_uart.pulses;
+    #if defined(INTMODULE_USART) || defined(EXTMODULE_USART)
+      modulePulsesData[port].pxx_uart.ptr = modulePulsesData[port].pxx_uart.pulses;
+    #endif
   }
   else{
 #if defined(PPM_PIN_SERIAL)


### PR DESCRIPTION
This will fix issue #11 - the code will build for PCB=T12
I added two #if statements:
```
#if defined(INTMODULE_USART) || defined(EXTMODULE_USART)
...
#endif
```
around line 40 and line 110 in multi_arm.cpp

